### PR TITLE
June 2020 patch

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,18 +307,13 @@ layout: default
 <script src="js/lookup_tool.js"></script>
 <script type='text/javascript'>
   //<![CDATA[
+    var DEBUG = false;
 
     $(function() {
 
       var autocomplete = new google.maps.places.Autocomplete(document.getElementById('address'), {types: ['address']});
 
       $("#address").val(convertToPlainString($.address.parameter('address')));
-      if ($("#address").val())
-        addressSearch();
-      
-      $('#address-search').click(function(){
-        addressSearch();
-      });
 
       var results_level = $.address.parameter('results_level');
       if (results_level == undefined)
@@ -353,6 +348,15 @@ layout: default
               $('#address-search').click();
               return false;
           }
+      });
+
+      if ($("#address").val()) {
+        if (DEBUG) console.log("search on load")
+        addressSearch();
+      }
+      
+      $('#address-search').click(function(){
+        addressSearch();
       });
     });
   //]]>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,6 @@ layout: default
         </div>
         <div id='response-container' style="display:none;">
 
-            <div class='text-center' id='address-image'></div>
-
-            <br />
             <br />
 
             <p class="lead text-center" id='results-nav'>

--- a/js/lookup_tool.js
+++ b/js/lookup_tool.js
@@ -1,3 +1,4 @@
+var DEBUG = false;
 var geocoder = new google.maps.Geocoder;
 var INFO_API = 'https://www.googleapis.com/civicinfo/v2/representatives';
 
@@ -62,11 +63,13 @@ function addressSearch() {
 
     $.address.parameter('results_level', results_level_set);
 
-    // console.log('doin search')
-    // console.log('local: ' + show_local)
-    // console.log('county: ' + show_county)
-    // console.log('state: ' + show_state)
-    // console.log('federal: ' + show_federal)
+    if (DEBUG) {
+        console.log('doin search')
+        console.log('local: ' + show_local)
+        console.log('county: ' + show_county)
+        console.log('state: ' + show_state)
+        console.log('federal: ' + show_federal)
+    }
     var address = $('#address').val();
     $.address.parameter('address', encodeURIComponent(address));
 
@@ -92,8 +95,10 @@ function addressSearch() {
         var county_people = [];
         var local_people = [];
 
-        // console.log(data);
-        // console.log(divisions);
+        if (DEBUG) {
+            console.log(data);
+            console.log(divisions);
+        }
 
         if (divisions === undefined) {
             $("#no-response-container").show();
@@ -103,7 +108,7 @@ function addressSearch() {
             setFoundDivisions(divisions);
 
             $.each(divisions, function(division_id, division){
-                // console.log(division.name);
+                if (DEBUG) console.log(division.name);
                 if (typeof division.officeIndices !== 'undefined'){
                     
                     $.each(division.officeIndices, function(i, office){
@@ -122,7 +127,7 @@ function addressSearch() {
                                 'pseudo_id': pseudo_id
                             };
 
-                            // console.log(officials[official])
+                            if (DEBUG) console.log(officials[official])
                             var person = officials[official];
                             info['person'] = person;
 
@@ -171,8 +176,6 @@ function addressSearch() {
                     });
                 }
             });
-
-            $("#address-image").html("<img class='img-responsive img-thumbnail' src='https://maps.googleapis.com/maps/api/staticmap?size=600x200&maptype=roadmap&markers=" + encodeURIComponent(address) + "' alt='" + address + "' title='" + address + "' />");
 
             var template = new EJS({'text': $('#tableGuts').html()});
             
@@ -258,7 +261,7 @@ function findMe() {
             var accuracy = position.coords.accuracy;
             var coords = new google.maps.LatLng(latitude, longitude);
 
-            // console.log(coords);
+            if (DEBUG) console.log(coords);
 
             geocoder.geocode({
                 'location': coords
@@ -290,7 +293,7 @@ function setFoundDivisions(divisions){
     $("#county-nav").hide();
     $("#local-nav").hide();
 
-    // console.log(divisions)
+    if (DEBUG) console.log(divisions)
     $.each(divisions, function(division_id, division){
         if (state_pattern.test(division_id)) {
             selected_state = division.name;

--- a/js/lookup_tool.js
+++ b/js/lookup_tool.js
@@ -1,4 +1,3 @@
-var DEBUG = false;
 var geocoder = new google.maps.Geocoder;
 var INFO_API = 'https://www.googleapis.com/civicinfo/v2/representatives';
 

--- a/js/lookup_tool.js
+++ b/js/lookup_tool.js
@@ -10,7 +10,7 @@ var county_pattern = /ocd-division\/country:us\/state:\D{2}\/county:\D+/;
 var local_pattern = /ocd-division\/country:us\/state:\D{2}\/place:\D+/;
 var district_pattern = /ocd-division\/country:us\/district:\D+/;
 
-var federal_offices = ['United States Senate', 'United States House of Representatives']
+var federal_offices = ['United States Senate', 'United States House of Representatives', 'U.S. Senator', 'U.S. Representative']
 
 var social_icon_lookup = {
     'YouTube': 'youtube',


### PR DESCRIPTION
This update provides a few bugfixes and adds a flag for easier debugging.

Summary:
* adds `DEBUG` flag to `index.html`. When set to `true`, outputs helpful `console.log` messages
* removes the Google static map at the top of search results. This was not enabled due to a missing API key. However, given the amount of traffic this site has, the [Google API cost](https://developers.google.com/maps/documentation/maps-static/usage-and-billing) would be prohibitive to add, so I opted to remove it instead. Closes #19 
* places US Senators in the correct federal list by adding checks based on their office title. Closes #20 
* found and fixed a bug where results do not load properly when the page is loaded an address pre-polulated