### PR TITLE
adds javascript redirect for the healthy american

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -136,6 +136,13 @@
       </div>
     </div>
     <script src="js/analytics_lib.js"></script>
+    <script>
+
+      // redirecting traffic from The Healthy American, an anti-mask advocacy group, to the CDC page on wearing masks
+      if (document.referrer.indexOf("thehealthyamerican.org") !== -1) {
+         location.href = "https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover-guidance.html"; 
+      }
+    </script>
 
   </body>
 </html>


### PR DESCRIPTION
We've been getting a large volume of traffic from The Healthy American, an anti-mask wearing advocacy group.

This group is actively causing harm and their actions may lead to people dying of COVID-19. The science on the benefits of wearing masks is indisputable.

To help minimize this harm that My Reps enables, this pull request looks at the HTTP referrer and if it comes from their site, redirects them to the CDC page on wearing masks: https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/cloth-face-cover-guidance.html